### PR TITLE
Fix #45 - improve bounty identification

### DIFF
--- a/src/recentjournal.py
+++ b/src/recentjournal.py
@@ -128,11 +128,20 @@ class RecentJournal:
         try:
             if len(self.__journal_entries_log) < 2:
                 return False
-            else:
-                return ((self.__journal_entries_log[1].get("event", "").lower() == "bounty" 
-                        or self.__journal_entries_log[2].get("event", "").lower() == "bounty")
-                        and self.__journal_entries_log[0].get("event", "").lower() == "powerplaymerits")
-        except IndexError as e:
+            # First entry must be powerplaymerits
+            if self.__journal_entries_log[0].get("event", "").lower() != "powerplaymerits":
+                return False
+            # Scan through subsequent entries, skipping shiptargeted, looking for bounty
+            for entry in self.__journal_entries_log[1:]:
+                event = entry.get("event", "").lower()
+                if event == "shiptargeted":
+                    continue
+                if event == "bounty":
+                    return True
+                # If we hit any other event before bounty, stop searching
+                break
+            return False
+        except IndexError:
             return False
 
     @property

--- a/tests/test_recentjournal.py
+++ b/tests/test_recentjournal.py
@@ -171,5 +171,15 @@ class TestRecentJournal(unittest.TestCase):
         self.recent_journal.add_entry({"timestamp":"2025-05-18T10:02:47Z","event":"PowerplayMerits","Power":"Jerome Archer","MeritsGained":268,"TotalMerits":1205795})
         self.assertTrue(self.recent_journal.isCommitCrimes)
 
+    def test_is_bounty2(self):
+        """
+        Test the isBounty property.
+        """
+        self.recent_journal.add_entry({"timestamp":"2025-05-19T19:57:28Z", "event":"Bounty", "Rewards":[ { "Faction":"Inara Nexus", "Reward":372898 } ], "PilotName":"$npc_name_decorate:#name=aigy;", "PilotName_Localised":"aigy", "Target":"krait_mkii", "Target_Localised":"Krait Mk II", "TotalReward":372898, "VictimFaction":"Terra Formations Industries"})
+        self.recent_journal.add_entry({"timestamp":"2025-05-19T19:57:28Z", "event":"ShipTargeted", "TargetLocked":False})
+        self.recent_journal.add_entry({"timestamp":"2025-05-19T19:57:28Z", "event":"ShipTargeted", "TargetLocked":True, "Ship":"krait_mkii", "Ship_Localised":"Krait Mk II", "ScanStage":3, "PilotName":"$npc_name_decorate:#name=Weltschmertz;", "PilotName_Localised":"Weltschmertz", "PilotRank":"Master", "ShieldHealth":64.881157, "HullHealth":100.000000, "Faction":"Terra Formations Industries", "LegalStatus":"Wanted", "Bounty":602879})
+        self.recent_journal.add_entry({"timestamp":"2025-05-19T19:57:35Z", "event":"PowerplayMerits", "Power":"Jerome Archer", "MeritsGained":91, "TotalMerits":1207320})
+        self.assertTrue(self.recent_journal.isBounty)
+        
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fix #45 - Add test and fix to ignore multiple shiptargeted events between powerplaymerits and the bounty event