### PR TITLE
Update powerplayprogress.py to fix locale usage on Linux

### DIFF
--- a/src/powerplayprogress.py
+++ b/src/powerplayprogress.py
@@ -591,7 +591,7 @@ class PowerPlayProgress:
         # Get the system's default locale
         default_locale = locale.getlocale()
         # Set the locale to the system's default
-        locale.setlocale(locale.LC_ALL, default_locale[0])
+        locale.setlocale(locale.LC_ALL, '.'.join(default_locale))
 
         ## Update the progress bar and label with the current session data
         if self.options_view_progress_bar.get():


### PR DESCRIPTION
The plugin did not work with EDMC 6.0.2 (python v3.13.11) on Linux. Looking at the EDMC logs revealed the following error:
```python
2026-01-04 22:33:51.039 UTC - ERROR - 4394:139790775081920:4394 plug.notify_journal_entry:376: Plugin "PowerPlayProgress" failed
Traceback (most recent call last):
  File "/home/operator/Games/Elite Tools/EDMC/EDMarketConnector/plug.py", line 373, in notify_journal_entry
    newerror = journal_entry(cmdr, is_beta, system, station, dict(entry), dict(state))
  File "/home/operator/.local/share/EDMarketConnector/plugins/EDMC-PowerPlayProgress/load.py", line 343, in journal_entry
    if ppp.total_merits > 0 and new_event: ppp.Update_Ppp_Display()
                                           ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/operator/.local/share/EDMarketConnector/plugins/EDMC-PowerPlayProgress/powerplayprogress.py", line 594, in Update_Ppp_Display
    locale.setlocale(locale.LC_ALL, default_locale[0])
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/locale.py", line 615, in setlocale
    return _setlocale(category, locale)
locale.Error: unsupported locale setting
```
The proposed fix should concatenate the `locale.getlocale()` output to provide a valid locale string.
Only tested on Linux, not sure if it's even an issue on Windows. If so, some OS specific handling might be required.